### PR TITLE
fix: prevent pushing images in PR

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -137,7 +137,7 @@ jobs:
           - "11-jdk-noble-mvn-loaded"
           - "17-jdk-noble-mvn-loaded"
     container:
-      image: ghcr.io/jahia/jahia-docker-mvn-cache:${{ matrix.container_version }}${{ env.IMAGE_SUFFIX }}
+      image: ghcr.io/jahia/jahia-docker-mvn-cache:${{ matrix.container_version }}
       credentials:
         username: ${{ secrets.GH_PACKAGES_USERNAME }}
         password: ${{ secrets.GH_PACKAGES_TOKEN }}


### PR DESCRIPTION
This is correcting a mistake in the original implementation.

With this fix, the branch name will get added automatically to the image name if the workflow is executed from a branch other than the repo's default.