### PR TITLE
feat: cache NVD CVE Data (WIP)

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -94,6 +94,8 @@ jobs:
           tags: ghcr.io/jahia/jahia-docker-mvn-cache:${{ env.DEFAULT_VERSION }}-mvn-loaded${{ env.IMAGE_SUFFIX }}
           cache-from: type=gha,scope=mvn-${{ env.DEFAULT_VERSION }}-hash-${{ steps.jahia-private-repo-hash.outputs.hash }}{{ env.IMAGE_SUFFIX }}
           cache-to: type=gha,mode=max,scope=mvn-${{ env.DEFAULT_VERSION }}-hash-${{ steps.jahia-private-repo-hash.outputs.hash }}{{ env.IMAGE_SUFFIX }}
+          secrets: |
+            nvd_api_key=${{ secrets.NVD_APIKEY }}
           build-args: |
             SRC_IMAGE=ghcr.io/jahia/jahia-docker-mvn-cache:${{ env.DEFAULT_VERSION }}-node-base${{ env.IMAGE_SUFFIX }}
 

--- a/Dockerfile-mvn
+++ b/Dockerfile-mvn
@@ -51,3 +51,7 @@ RUN --mount=type=ssh bash -lc '\
     rm -rf dummy-project && \
     echo "Remove SNAPSHOT dependencies from the local Maven repository as, by nature, they are supposed to change" && \
     find ~/.m2/repository -name "*-SNAPSHOT" -type d -exec rm -rf {} + 2>/dev/null || true'
+
+RUN curl -L -o /tmp/vulnz.jar https://github.com/jeremylong/open-vulnerability-cli/releases/download/v9.0.4/vulnz-9.0.4.jar
+RUN chmod u+x /tmp/vulnz.jar
+RUN --mount=type=secret,id=nvd_api_key NVD_API_KEY=$(cat /run/secrets/nvd_api_key) /tmp/vulnz.jar cve --cache --directory /tmp/.vulnz_cache


### PR DESCRIPTION
**⚠️ work in progress ⚠️** 

### Description
Cache the NVD CVE Data using `open-vulnerability-cli`: https://github.com/jeremylong/open-vulnerability-cli/blob/main/README.md#mirroring-the-nvd-cve-data


> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
