### PR TITLE
chore: updated ubuntu base image from noble to resolute

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -11,7 +11,7 @@ on:
     types: [opened, synchronize, reopened]
 
 env:
-  DEFAULT_VERSION: 17-jdk-noble
+  DEFAULT_VERSION: 17-jdk-resolute
 
 jobs:
   # Builds a base image containing the maven cache
@@ -112,8 +112,8 @@ jobs:
     strategy:
       matrix:
         jdk_version:
-          - "8-jdk-noble"
-          - "11-jdk-noble"
+          - "8-jdk-resolute"
+          - "11-jdk-resolute"
     steps:
       - uses: actions/checkout@v5
       - name: Login to GitHub registry
@@ -196,11 +196,11 @@ jobs:
     strategy:
       matrix:
         include:
-          - container_version: "8-jdk-noble-mvn-loaded"
+          - container_version: "8-jdk-resolute-mvn-loaded"
             expected_java_version: "1.8"
-          - container_version: "11-jdk-noble-mvn-loaded"
+          - container_version: "11-jdk-resolute-mvn-loaded"
             expected_java_version: "11"
-          - container_version: "17-jdk-noble-mvn-loaded"
+          - container_version: "17-jdk-resolute-mvn-loaded"
             expected_java_version: "17"
     container:
       image: ghcr.io/jahia/jahia-docker-mvn-cache:${{ matrix.container_version }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,6 @@ RUN apt-get update \
   && apt-get install -y \
     nodejs \
     npm \
-    yarn \
     curl \
     ca-certificates \
     git \
@@ -22,6 +21,7 @@ RUN apt-get update \
     bash \
     tar \
   && npm i -g corepack \
+  && npm i -g yarn \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
 # Installed corepack separately because not installed when using apt or brew

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_TAG=17-jdk-noble
+ARG BASE_TAG=17-jdk-resolute
 
 FROM eclipse-temurin:$BASE_TAG
 LABEL maintainer="Jahia"
@@ -6,7 +6,7 @@ LABEL maintainer="Jahia"
 ARG REFRESHED_AT
 ENV REFRESHED_AT=$REFRESHED_AT
 
-ARG MAVEN_VERSION=3.9.11
+ARG MAVEN_VERSION=3.9.16
 ENV MAVEN_HOME=/opt/maven \
   MAVEN_CONFIG=/root/.m2
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ RUN apt-get update \
     bash \
     tar \
   && npm i -g corepack \
-  && npm i -g yarn \
+  && corepack prepare yarn@1 --activate \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
 # Installed corepack separately because not installed when using apt or brew

--- a/Dockerfile-fromcache
+++ b/Dockerfile-fromcache
@@ -1,5 +1,5 @@
-ARG SRC_IMAGE=ghcr.io/jahia/jahia-docker-mvn-cache:11-jdk-noble-node-base
-ARG CACHE_IMAGE=ghcr.io/jahia/jahia-docker-mvn-cache:17-jdk-noble-mvn-loaded
+ARG SRC_IMAGE=ghcr.io/jahia/jahia-docker-mvn-cache:11-jdk-resolute-node-base
+ARG CACHE_IMAGE=ghcr.io/jahia/jahia-docker-mvn-cache:17-jdk-resolute-mvn-loaded
 
 FROM $CACHE_IMAGE AS cache
 

--- a/Dockerfile-mvn
+++ b/Dockerfile-mvn
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.7
-ARG SRC_IMAGE=ghcr.io/jahia/jahia-docker-mvn-cache:17-jdk-noble-node-base
+ARG SRC_IMAGE=ghcr.io/jahia/jahia-docker-mvn-cache:17-jdk-resolute-node-base
 
 FROM $SRC_IMAGE
 LABEL maintainer="Jahia"

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ High-level flow (example using JDK 17 as the default):
 
 ```
                          ┌──────────────────────────────────────┐
-                         │  Dockerfile (17-jdk-noble)           │  (fast)
+                         │  Dockerfile (17-jdk-resolute)           │  (fast)
                          │  - JDK + Node + Maven (no cache)     │
                          └───────────────┬──────────────────────┘
                                          │ build & push base image
@@ -35,7 +35,7 @@ High-level flow (example using JDK 17 as the default):
                   ┌──────────────────────┴────────────────────────────────┐
                   │                                                       │
   ┌──────────────────────────────────────┐              ┌──────────────────────────────────────┐
-  │  Dockerfile      (8-jdk-noble)       │  (fast)      │  Dockerfile      (11-jdk-noble)      │  (fast)
+  │  Dockerfile      (8-jdk-resolute)       │  (fast)      │  Dockerfile      (11-jdk-resolute)      │  (fast)
   │  - JDK + Node + Maven (no cache)     │              │  - JDK + Node + Maven (no cache)     │
   └───────────────┬──────────────────────┘              └───────────────┬──────────────────────┘
                   │                                                     │
@@ -54,29 +54,29 @@ Key idea: warm the Maven cache once in a default image, then other images copy t
 
 ## Build image locally
 
-From an ARM64 host, build a base image (name: `ghcr.io/jahia/jahia-docker-mvn-cache:11-jdk-noble-node-base`)
+From an ARM64 host, build a base image (name: `ghcr.io/jahia/jahia-docker-mvn-cache:11-jdk-resolute-node-base`)
 
 ```bash
 docker buildx build \
   --platform linux/amd64 \
   --build-arg REFRESHED_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
-  --build-arg BASE_TAG="11-jdk-noble" \
-  -t ghcr.io/jahia/jahia-docker-mvn-cache:11-jdk-noble-node-base \
+  --build-arg BASE_TAG="11-jdk-resolute" \
+  -t ghcr.io/jahia/jahia-docker-mvn-cache:11-jdk-resolute-node-base \
   -f Dockerfile \
   --push \
   .
 ```
 
-Once the base image is ready, build the maven cache image (name: `ghcr.io/jahia/jahia-docker-mvn-cache:11-jdk-noble-mvn-loaded`)
+Once the base image is ready, build the maven cache image (name: `ghcr.io/jahia/jahia-docker-mvn-cache:11-jdk-resolute-mvn-loaded`)
 
 ```bash
 docker buildx build \
   --platform linux/amd64 \
-  --build-arg SRC_IMAGE="ghcr.io/jahia/jahia-docker-mvn-cache:11-jdk-noble-node-base" \
+  --build-arg SRC_IMAGE="ghcr.io/jahia/jahia-docker-mvn-cache:11-jdk-resolute-node-base" \
   --load \
   --ssh default \
   --pull \
-  -t ghcr.io/jahia/jahia-docker-mvn-cache:11-jdk-noble-mvn-loaded \
+  -t ghcr.io/jahia/jahia-docker-mvn-cache:11-jdk-resolute-mvn-loaded \
   -f Dockerfile-mvn \
   .
 ```
@@ -87,5 +87,5 @@ Finally, open a bash session inside the container
 docker run --rm -it \
   --platform linux/amd64 \
   --entrypoint /bin/sh \
-  ghcr.io/jahia/jahia-docker-mvn-cache:11-jdk-noble-mvn-loaded
+  ghcr.io/jahia/jahia-docker-mvn-cache:11-jdk-resolute-mvn-loaded
 ```


### PR DESCRIPTION
Updated from Ubuntu Noble (LTS) to Ubuntu Resolute (LTS) 

Verified the tags were available on Docker Hub:
 - [8-jdk-resolute](https://hub.docker.com/layers/library/eclipse-temurin/8-jdk-resolute/images/sha256-892b3431873e825475e517f81cdf258dafbbc1e2153b2a53db2e70883bfc72f7)
 - [11-jdk-resolute](https://hub.docker.com/layers/library/eclipse-temurin/11-jdk-resolute/images/sha256-091f15a4f0718b1b6854c47173ebac5b82a123320248e176178f1865810e0b21)
 - [17-jdk-resolute](https://hub.docker.com/layers/library/eclipse-temurin/17-jdk-resolute/images/sha256-7383a9e8e67a003c0e32ccdee3e5352ec24ca9c3848080c3f108bddb0322139e)

Note that this does change the base image tag, which means we'll need to adopt it in our reusable workflows. This is not necessarily a bad thing, the old tag will still be used (with the old image) until updated.

From:
```
ghcr.io/jahia/jahia-docker-mvn-cache:11-jdk-noble-mvn-loaded
ghcr.io/jahia/jahia-docker-mvn-cache:17-jdk-noble-mvn-loaded
```

To:
```
ghcr.io/jahia/jahia-docker-mvn-cache:11-jdk-resolute-mvn-loaded
ghcr.io/jahia/jahia-docker-mvn-cache:17-jdk-resolute-mvn-loaded
```

Search: 
- https://github.com/search?q=org%3AJahia+%22ghcr.io%2Fjahia%2Fjahia-docker-mvn-cache%3A11%22&type=code
- https://github.com/search?q=org%3AJahia+%22ghcr.io%2Fjahia%2Fjahia-docker-mvn-cache%3A17%22&type=code